### PR TITLE
Bug fix:  .bib files with comments

### DIFF
--- a/src/latex_envs/static/bibtex2.js
+++ b/src/latex_envs/static/bibtex2.js
@@ -212,7 +212,7 @@ function BibtexParser() {
   }
 
   this.comment = function() {
-    this.value(); // this is wrong
+    while(!this.tryMatch("}")) {this.pos++;}
   }
 
   this.entry = function(d) {


### PR DESCRIPTION
When the .bib file contains comments (like jabref files), the library failed at parsing.